### PR TITLE
Added check for default register

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ A: Because then you have to deal with escaping termcodes, quotes, etc. yourself.
 
 > _Note: Telescope picker coming soon!_
 
+## Installation
+For [lazy.vim](https://github.com/folke/lazy.nvim)
+```lua
+  {
+    "jesseleite/nvim-macroni",
+    cmd = "YankMacro",
+    keys = {
+      { "<leader>ym", [[:YankMacro ]], mode = "n", desc = "Yank Macro" }, -- optional
+    },
+  },
+```
+
 ## Usage
 
 Simply run `:YankMacro [register]` to yank a recorded macro from a register, then paste the macro directly into a custom mapping or function in your config 🤌

--- a/lua/macroni/init.lua
+++ b/lua/macroni/init.lua
@@ -1,52 +1,58 @@
+local util = require("macroni.util")
 local M = {}
 
 local macros = {}
 
 function M.setup(opts)
-  macros = opts.macros or {}
+	macros = opts.macros or {}
 
--- Experimental, may change!
-  for key,macro in pairs(macros) do
-    if macro ~= 'string' and macro.keymap and macro.macro then
-      vim.keymap.set('n', macro.keymap, function () M.runSaved(key) end, {
-        desc = 'Saved macro: '..(macro.desc or key),
-        remap = true,
-      })
-    end
-  end
+	-- Experimental, may change!
+	for key, macro in pairs(macros) do
+		if macro ~= "string" and macro.keymap and macro.macro then
+			vim.keymap.set("n", macro.keymap, function()
+				M.runSaved(key)
+			end, {
+				desc = "Saved macro: " .. (macro.desc or key),
+				remap = true,
+			})
+		end
+	end
 end
 
 function M.yank(register)
-  register = register or vim.fn.input('Please specify a register to yank from: ')
-  vim.cmd.mode()
+	register = register or vim.fn.input("Please specify a register to yank from: ")
+	vim.cmd.mode()
 
-  local register_content = vim.fn.getreg(register)
+	local register_content = vim.fn.getreg(register)
 
-  if register == '' or register_content == '' then
-    print('Invalid register content!')
-    return
-  end
+	if register == "" or register_content == "" then
+		print("Invalid register content!")
+		return
+	end
 
-  local macro = vim.fn.keytrans(register_content)
-  vim.fn.setreg('+', macro)
-  vim.fn.setreg('*', macro)
-  vim.fn.setreg('"', macro)
-
-  print('Yanked macro from register `'..register..'`')
+	local macro = vim.fn.keytrans(register_content)
+	if util.get_default_register() == "+" then
+		vim.fn.setreg("+", macro)
+		vim.fn.setreg('"', macro)
+	else
+		vim.fn.setreg("*", macro)
+		vim.fn.setreg('"', macro)
+	end
+	print("Yanked macro from register `" .. register .. "`")
 end
 
 function M.run(macro)
-  vim.cmd.normal(vim.api.nvim_replace_termcodes(macro, true, true, true))
+	vim.cmd.normal(vim.api.nvim_replace_termcodes(macro, true, true, true))
 end
 
 -- Experimental, may change!
 -- TODO: Build telescope picker to easily select a saved macro
 function M.runSaved(key)
-  local macro = macros[key]
-  if type(macro) == 'string' then
-    return M.run(macro)
-  end
-  return M.run(macro.macro)
+	local macro = macros[key]
+	if type(macro) == "string" then
+		return M.run(macro)
+	end
+	return M.run(macro.macro)
 end
 
 return M

--- a/lua/macroni/util.lua
+++ b/lua/macroni/util.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+function M.get_default_register()
+	local clipboardFlags = vim.split(vim.api.nvim_get_option("clipboard"), ",")
+	if vim.tbl_contains(clipboardFlags, "unnamedplus") then
+		return "+"
+	end
+	if vim.tbl_contains(clipboardFlags, "unnamed") then
+		return "*"
+	end
+	return '"'
+end
+
+return M


### PR DESCRIPTION
If the clipboard option is set to "unnamedplus" the default way we yank macros doesn't work.

`vim.fn.setreg('+', macro)` and  `vim.fn.setreg('*', macro)` don't work well together.

So, I added a check to see if clipboard is set to "unnamedplus" and then perform the yank properly.

Nice Talk and Nice plugin!